### PR TITLE
Change encodeParams error message

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ function Result() {}
 
 function encodeParams(types, values) {
   if (types.length !== values.length) {
-    throw new Error('types/values mismatch');
+    throw new Error(`Your contract requires ${types.length} types, and you passed in ${values.length}`);
   }
 
   var parts = [];


### PR DESCRIPTION
The error message for `encodeParams()` was not very descriptive. However, I am not sure if this error will be thrown in moments where this more specific error message will be misleading.

I would love for `ethjs` to take a page out of `elm`'s book and use really descriptive errors, not that my message was the best or even accurate.

## ethjs-abi

Thank you for contributing! Please take a moment to review our [**contributing guidelines**](https://github.com/ethjs/ethjs-abi/blob/master/.github/CONTRIBUTING.md)
to make the process easy and effective for everyone involved.

**Please open an issue** before embarking on any significant pull request, especially those that
add a new library or change existing tests, otherwise you risk spending a lot of time working
on something that might not end up being merged into the project.

Before opening a pull request, please ensure:

- [x] You have followed our [**contributing guidelines**](https://github.com/ethjs/ethjs-abi/blob/master/.github/CONTRIBUTING.md)
- [x] Pull request has tests (we are going for 100% coverage!)
- [x] Code is well-commented, linted and follows project conventions
- [x] Documentation is updated (if necessary)
- [x] Internal code generators and templates are updated (if necessary)
- [x] Description explains the issue/use-case resolved and auto-closes related issues

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)

**IMPORTANT**: By submitting a patch, you agree to allow the project
owners to license your work under the terms of the [MIT License](https://github.com/ethjs/ethjs-abi/blob/master/LICENSE.md).