### PR TITLE
Symbol.iterator for Result

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,11 +19,14 @@ const paramTypePart = utils.paramTypePart;
 const getParamCoder = utils.getParamCoder;
 
 function Result() {
-  this[Symbol.iterator] = function* () {
-    const keys = Object.keys(this);
-    for (key of keys) {
-      if (!this.hasOwnProperty(key) || !Number.isFinite(Number(key))) continue
-      yield this[key];
+  this[Symbol.iterator] = () => {
+    const keys = Object.keys(this)
+      .filter(key => Number.isFinite(Number(key)))
+    return {
+      next: () => {
+        if (!keys.length) return { value: undefined, done: true }
+        return { value: this[keys.shift()], done: false }
+      }
     }
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,15 @@ const coderArray = utils.coderArray;
 const paramTypePart = utils.paramTypePart;
 const getParamCoder = utils.getParamCoder;
 
-function Result() {}
+function Result() {
+  this[Symbol.iterator] = function* () {
+    const keys = Object.keys(this);
+    for (key of keys) {
+      if (!this.hasOwnProperty(key) || !Number.isFinite(Number(key))) continue
+      yield this[key];
+    }
+  }
+}
 
 function encodeParams(types, values) {
   if (types.length !== values.length) {


### PR DESCRIPTION
Added the `Symbol.iterator` method to instances of `Result`. If everyone's into it, I can write a couple test cases to keep coverage at 100%. Once merged, this would close #12.